### PR TITLE
Add each_with_index to vector

### DIFF
--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -162,6 +162,10 @@ module Rover
       to_a.each(&block)
     end
 
+    def each_with_index(&block)
+      @data.each_with_index(&block)
+    end
+
     def max
       @data.max
     end

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -288,6 +288,14 @@ class VectorTest < Minitest::Test
     assert_vector [1, 3], vector[where]
   end
 
+  def test_each_with_index
+    array_data = [1,2,3,4,5]
+    vector = Rover::Vector.new(array_data)
+    vector.each_with_index do |int, index|
+      assert_equal int, array_data[index]
+    end
+  end
+
   # converters
 
   def test_to_a


### PR DESCRIPTION
I think each_with_index is often useful when you want to read data from multiple vectors. This PR adds `each_with_index` to `Rover::Vector`. I did notice that the `each` implementation first converts the Numo vector to an array - but Numo already has a `each` and `each_with_index`, so I am just passing the block to the numo vector. Let me know if there's a reason for the `to_a` conversion and I'm happy to do the same.