### PR TITLE
Support casting vectors to other data types

### DIFF
--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -22,6 +22,18 @@ module Rover
       raise ArgumentError, "Bad size: #{@data.shape}" unless @data.ndim == 1
     end
 
+    def to_dfloat
+      Vector.new(@data.cast_to(Numo::DFloat))
+    end
+
+    def to_int32
+      Vector.new(@data.cast_to(Numo::Int32))
+    end
+
+    def to_int64
+      Vector.new(@data.cast_to(Numo::Int64))
+    end
+
     def to_numo
       @data
     end

--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -1,5 +1,13 @@
 module Rover
   class Vector
+
+    TYPE_CAST_MAPPING = {
+      boolean: Numo::Bit,
+      float: Numo::DFloat,
+      integer: Numo::Int64,
+      object: Numo::RObject
+    }
+
     def initialize(data)
       @data =
         if data.is_a?(Vector)
@@ -22,16 +30,16 @@ module Rover
       raise ArgumentError, "Bad size: #{@data.shape}" unless @data.ndim == 1
     end
 
-    def to_dfloat
-      Vector.new(@data.cast_to(Numo::DFloat))
-    end
+    def to(type)
+      numo_type = TYPE_CAST_MAPPING[type]
 
-    def to_int32
-      Vector.new(@data.cast_to(Numo::Int32))
-    end
-
-    def to_int64
-      Vector.new(@data.cast_to(Numo::Int64))
+      if numo_type == Numo::DFloat && @data.class == Numo::RObject
+        Vector.new(@data.to_a.map { |item| item.to_f })
+      elsif numo_type == Numo::Int64 && @data.class == Numo::RObject
+        Vector.new(@data.to_a.map { |item| item.to_i })
+      else
+        Vector.new(@data.cast_to(numo_type))
+      end
     end
 
     def to_numo

--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -33,9 +33,9 @@ module Rover
     def to(type)
       numo_type = TYPE_CAST_MAPPING[type]
 
-      if numo_type == Numo::DFloat && @data.class == Numo::RObject
-        Vector.new(@data.to_a.map { |item| item.to_f })
-      elsif numo_type == Numo::Int64 && @data.class == Numo::RObject
+      if numo_type == Numo::DFloat && @data.is_a?(Numo::RObject)
+        Vector.new(@data.to_a.map { |item| item.nil? ? Float::NAN : item.to_f })
+      elsif numo_type == Numo::Int64 && @data.is_a?(Numo::RObject)
         Vector.new(@data.to_a.map { |item| item.to_i })
       else
         Vector.new(@data.cast_to(numo_type))

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -311,28 +311,28 @@ class VectorTest < Minitest::Test
     vector = Rover::Vector.new([1.0,2.0,3.0, nil])
     vector = vector.to(:integer)
     assert_equal vector[0], 1
-    assert_equal vector.to_numo.class, Numo::Int64
+    assert_kind_of Numo::Int64, vector.to_numo
 
     vector = Rover::Vector.new(["1","2","3"])
     vector = vector.to(:integer)
     assert_equal vector[0], 1
     assert_equal vector[1], 2
     assert_equal vector[2], 3
-    assert_equal vector.to_numo.class, Numo::Int64
+    assert_kind_of Numo::Int64, vector.to_numo
   end
 
   def test_to_float
     vector = Rover::Vector.new([1,2,3, nil])
     vector = vector.to(:float)
     assert_equal vector[0], 1.0
-    assert_equal vector.to_numo.class, Numo::DFloat
+    assert_kind_of Numo::DFloat, vector.to_numo
 
     vector = Rover::Vector.new(["1.0","2.1",nil])
     vector = vector.to(:float)
     assert_equal vector[0], 1.0
     assert_equal vector[1], 2.1
-    assert_equal vector[2], nil
-    assert_equal vector.to_numo.class, Numo::DFloat
+    assert_equal vector[2].nan?, true
+    assert_kind_of Numo::DFloat, vector.to_numo
   end
 
   def test_to_boolean
@@ -341,7 +341,7 @@ class VectorTest < Minitest::Test
     assert_equal vector[0], 1
     assert_equal vector[1], 1
     assert_equal vector[2], 0
-    assert_equal vector.to_numo.class, Numo::Bit
+    assert_kind_of Numo::Bit, vector.to_numo
   end
 
   def test_to_a

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -307,6 +307,27 @@ class VectorTest < Minitest::Test
 
   # converters
 
+  def test_to_int32
+    vector = Rover::Vector.new([1.0,2.0,3.0, nil])
+    vector = vector.to_int32
+    assert_equal vector[0], 1
+    assert_equal vector.to_numo.class, Numo::Int32
+  end
+
+  def test_to_int64
+    vector = Rover::Vector.new([1.0,2.0,3.0, nil])
+    vector = vector.to_int64
+    assert_equal vector[0], 1
+    assert_equal vector.to_numo.class, Numo::Int64
+  end
+
+  def test_to_dfloat
+    vector = Rover::Vector.new([1,2,3, nil])
+    vector = vector.to_dfloat
+    assert_equal vector[0], 1.0
+    assert_equal vector.to_numo.class, Numo::DFloat
+  end
+
   def test_to_a
     vector = Rover::Vector.new(1..3)
     assert_equal [1, 2, 3], vector.to_a

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -307,25 +307,41 @@ class VectorTest < Minitest::Test
 
   # converters
 
-  def test_to_int32
+  def test_to_integer
     vector = Rover::Vector.new([1.0,2.0,3.0, nil])
-    vector = vector.to_int32
+    vector = vector.to(:integer)
     assert_equal vector[0], 1
-    assert_equal vector.to_numo.class, Numo::Int32
-  end
+    assert_equal vector.to_numo.class, Numo::Int64
 
-  def test_to_int64
-    vector = Rover::Vector.new([1.0,2.0,3.0, nil])
-    vector = vector.to_int64
+    vector = Rover::Vector.new(["1","2","3"])
+    vector = vector.to(:integer)
     assert_equal vector[0], 1
+    assert_equal vector[1], 2
+    assert_equal vector[2], 3
     assert_equal vector.to_numo.class, Numo::Int64
   end
 
-  def test_to_dfloat
+  def test_to_float
     vector = Rover::Vector.new([1,2,3, nil])
-    vector = vector.to_dfloat
+    vector = vector.to(:float)
     assert_equal vector[0], 1.0
     assert_equal vector.to_numo.class, Numo::DFloat
+
+    vector = Rover::Vector.new(["1.0","2.1",nil])
+    vector = vector.to(:float)
+    assert_equal vector[0], 1.0
+    assert_equal vector[1], 2.1
+    assert_equal vector[2], nil
+    assert_equal vector.to_numo.class, Numo::DFloat
+  end
+
+  def test_to_boolean
+    vector = Rover::Vector.new([1,2,0])
+    vector = vector.to(:boolean)
+    assert_equal vector[0], 1
+    assert_equal vector[1], 1
+    assert_equal vector[2], 0
+    assert_equal vector.to_numo.class, Numo::Bit
   end
 
   def test_to_a


### PR DESCRIPTION
The current state of this PR is more of a request for comment than a PR. I've prepared a few methods for casting the data in a vector to a specific data type. I think underlying this PR is a design decision around how much you want to expose or wrap the underlying numo implementation.

I've implemented and tested three methods. `to_int32`, `to_int64`, and `to_dfloat`. These make the design decision that Rover will expose and adhere to the data type for numo/NArray. The other option would be to provide a simplified interface to users and create `to_i` and `to_f` methods which cast data to `Numo::Int64` and `Numo::DFloat` respectively. This would require less knowledge about Rover's implementation and would follow ruby conventions more closely.

I'm curious for feedback on this. I'm sure there are other patterns I'm not thinking of.