### PR TITLE
fix vector last to work if data size is smaller than last n

### DIFF
--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -263,7 +263,11 @@ module Rover
     end
 
     def last(n = 1)
-      Vector.new(@data[-n..-1])
+      if n >= size
+        Vector.new(@data)
+      else
+        Vector.new(@data[-n..-1])
+      end
     end
 
     def take(n)

--- a/test/vector_test.rb
+++ b/test/vector_test.rb
@@ -331,6 +331,16 @@ class VectorTest < Minitest::Test
     assert_vector 2..3, vector.last(2)
   end
 
+  def test_last1
+    vector = Rover::Vector.new(1..1)
+    assert_vector 1..1, vector.last
+  end
+
+  def test_short_last
+    vector = Rover::Vector.new(1..3)
+    assert_vector 1..3, vector.last(4)
+  end
+
   def test_take
     vector = Rover::Vector.new(1..3)
     assert_vector 1..2, vector.take(2)


### PR DESCRIPTION
Vector last has a small bug when the vector is smaller than the number passed to last.