### PR TITLE
Improve speed of csv_to_df and read_csv

### DIFF
--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -52,8 +52,8 @@ module Rover
       if table_key.nil? then
         key="unnamed#{unnamed_suffix}"
         while h.include?(key)
-          key="unnamed#{unnamed_suffix}"
           unnamed_suffix+=1
+          key="unnamed#{unnamed_suffix}"
         end
       end
       data[key]=[]

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -50,8 +50,8 @@ module Rover
     k[0].each_with_index{|table_key,index|
       key=table_key
       if table_key.nil? then
-        key="unnamed"
-        while keys.include?(k)
+        key="unnamed#{unnamed_suffix}"
+        while keys.include?(key)
           key="unnamed#{unnamed_suffix}"
           unnamed_suffix+=1
         end

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -42,7 +42,6 @@ module Rover
       if headers && headers.size < table.headers.size
         raise ArgumentError, "Expected #{table.headers.size} headers, got #{headers.size}"
       end
-    data = {}
     k = table.to_a
     h = {}
     unnamed_suffix = 1

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -42,27 +42,31 @@ module Rover
       if headers && headers.size < table.headers.size
         raise ArgumentError, "Expected #{table.headers.size} headers, got #{headers.size}"
       end
-
-      table.by_col!
-      data = {}
-      keys = table.map { |k, _| [k, true] }.to_h
-      unnamed_suffix = 1
-      table.each do |k, v|
-        # TODO do same for empty string in 0.3.0
-        if k.nil?
-          k = "unnamed"
-          while keys.include?(k)
-            unnamed_suffix += 1
-            k = "unnamed#{unnamed_suffix}"
-          end
-          keys[k] = true
+    data = {}
+    k = table.to_a
+    h = {}
+    unnamed_suffix = 1
+    data={}
+    k[0].each_with_index{|table_key,index|
+      key=table_key
+      if table_key.nil? then
+        key="unnamed"
+        while keys.include?(k)
+          key="unnamed#{unnamed_suffix}"
+          unnamed_suffix+=1
         end
-        data[k] = v
       end
-
-      DataFrame.new(data, types: types)
+      data[key]=[]
+      h[index]=key
+    }
+    k.shift
+    k.each{|x|
+      x.each_with_index{|val,index|
+        data[h[index]].push(val)
+      }
+    }
+    DataFrame.new(data, types: types)
     end
-
     PARQUET_TYPE_MAPPING = {
       "bool" => Numo::Bit,
       "float" => Numo::SFloat,

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -51,7 +51,7 @@ module Rover
       key=table_key
       if table_key.nil? then
         key="unnamed#{unnamed_suffix}"
-        while keys.include?(key)
+        while h.include?(key)
           key="unnamed#{unnamed_suffix}"
           unnamed_suffix+=1
         end

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -46,8 +46,8 @@ module Rover
     unnamed_suffix = 1
     data = {}
     table.headers.each_with_index{|table_key,index|
-      key=table_key
-      if table_key.nil? then
+      key=table_key.to_s
+      if table_key.empty? then
         key="unnamed"
         while h.include?(k)
           key="unnamed#{unnamed_suffix}"

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -47,8 +47,8 @@ module Rover
     data = {}
     table.headers.each_with_index{|table_key,index|
       key=table_key.to_s
-      if table_key.empty? then
-        key="unnamed"
+      if key.empty? then
+        key="unnamed#{unnamed_suffix}"
         while h.include?(k)
           key="unnamed#{unnamed_suffix}"
           unnamed_suffix+=1

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -1,5 +1,3 @@
-
-   
 # dependencies
 require "numo/narray"
 
@@ -33,7 +31,7 @@ module Rover
     end
     def parse_csv(str, types: nil, **options)
       require "csv"
-      csv_to_df(CSV.parse(str, **csv_options(options)).to_a, types: types, headers: options[:headers])
+      csv_to_df(CSV.parse(str, **csv_options(options)), types: types, headers: options[:headers])
     end
 
     def read_parquet(path, types: nil)

--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -42,24 +42,23 @@ module Rover
       if headers && headers.size < table.headers.size
         raise ArgumentError, "Expected #{table.headers.size} headers, got #{headers.size}"
       end
-    k = table.to_a
     h = {}
     unnamed_suffix = 1
-    data={}
-    k[0].each_with_index{|table_key,index|
+    data = {}
+    table.headers.each_with_index{|table_key,index|
       key=table_key
       if table_key.nil? then
-        key="unnamed#{unnamed_suffix}"
-        while h.include?(key)
-          unnamed_suffix+=1
+        key="unnamed"
+        while h.include?(k)
           key="unnamed#{unnamed_suffix}"
+          unnamed_suffix+=1
         end
       end
       data[key]=[]
       h[index]=key
     }
-    k.shift
-    k.each{|x|
+    table.instance_variable_get(:@table).each{|x|
+      x=x.fields
       x.each_with_index{|val,index|
         data[h[index]].push(val)
       }


### PR DESCRIPTION
Regarding [this issue](https://github.com/ankane/rover/issues/20), I wrote this and found it was faster.
```ruby
h = {}
unnamed_suffix = 1
data = {}
table.headers.each_with_index{|table_key,index|
  key=table_key.to_s
  if table_key.empty? then
    key="unnamed"
    while h.include?(k)
      key="unnamed#{unnamed_suffix}"
      unnamed_suffix+=1
    end
  end
  data[key]=[]
  h[index]=key
}
table.instance_variable_get(:@table).each{|x|
  x=x.fields
  x.each_with_index{|val,index|
    data[h[index]].push(val)
  }
}
```
When I used ruby-prof, it showed a time change from ~28 seconds to ~12 seconds on the dataset linked in the above issue.