### PR TITLE
Add numerical summary/describe for DataFrame

### DIFF
--- a/lib/rover/data_frame.rb
+++ b/lib/rover/data_frame.rb
@@ -346,6 +346,28 @@ module Rover
     end
     alias_method :describe, :summary
 
+    # This method may be abandoned
+    # - Counts sould be Int but casted to Float
+    def summary_T
+      num_keys = self.keys.select {|key| self[key].numeric?}
+      # use key of 1st column to show n_rows and n_of_numeric_columns
+      nrow, _ = self.shape
+      key0 = :"[#{nrow},#{num_keys.size}]"
+      round = 6
+
+      ary = [] <<
+        num_keys.each_with_object({key0 => "count"}) {|k, h| h[k] = self[k].missing.to_numo.count_false } <<
+        num_keys.each_with_object({key0 => "mean"})  {|k, h| h[k] = self[k].mean.round(round) } <<
+        num_keys.each_with_object({key0 => "std"})   {|k, h| h[k] = self[k].std.round(round) } <<
+        num_keys.each_with_object({key0 => "min"})   {|k, h| h[k] = self[k].min } <<
+        num_keys.each_with_object({key0 => "25%"})   {|k, h| h[k] = self[k].percentile(25).round(round) } <<
+        num_keys.each_with_object({key0 => "50%"})   {|k, h| h[k] = self[k].percentile(50).round(round) } <<
+        num_keys.each_with_object({key0 => "75%"})   {|k, h| h[k] = self[k].percentile(75).round(round) } <<
+        num_keys.each_with_object({key0 => "max"})   {|k, h| h[k] = self[k].max }
+
+      Rover::DataFrame.new(ary)
+    end
+
     def sort_by!
       indexes =
         size.times.sort_by do |i|

--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -220,13 +220,13 @@ module Rover
     def mean
       # currently only floats have mean in Numo
       # https://github.com/ruby-numo/numo-narray/issues/79
-      @data.cast_to(Numo::DFloat).mean
+      @data.cast_to(Numo::DFloat).mean(nan: true)
     end
 
     def median
       # need to cast to get correct result
       # https://github.com/ruby-numo/numo-narray/issues/165
-      @data.cast_to(Numo::DFloat).median
+      @data.cast_to(Numo::DFloat).median(nan: true)
     end
 
     def percentile(q)
@@ -239,12 +239,12 @@ module Rover
 
     # uses Bessel's correction for now since that's all Numo supports
     def std
-      @data.cast_to(Numo::DFloat).stddev
+      @data.cast_to(Numo::DFloat).stddev(nan: true)
     end
 
     # uses Bessel's correction for now since that's all Numo supports
     def var
-      @data.cast_to(Numo::DFloat).var
+      @data.cast_to(Numo::DFloat).var(nan: true)
     end
 
     def all?(&block)

--- a/test/data_frame_test.rb
+++ b/test/data_frame_test.rb
@@ -439,4 +439,12 @@ class DataFrameTest < Minitest::Test
     df["a"][1] = 0
     assert_vector [1, 2, 3], df2["a"]
   end
+
+  def test_summary
+    df = Rover::DataFrame.new(a: [1,2,3])
+    assert df.summary.is_a? Rover::DataFrame
+    expected = "[3,1]  count  mean  std  min  25%  50%  75%  max\n    a      3   2.0  1.0    1  1.5  2.0  2.5    3"
+    assert_equal expected, df.summary.to_s
+    assert_equal "[0,0]  count  mean  std  min  25%  50%  75%  max", Rover::DataFrame.new().describe.to_s
+  end
 end


### PR DESCRIPTION
This is a proposal about #25 (describe) and #34 (summary), experimental summary/describe method for DataFrame.

- Returns DataFrame
- Only for numerical columns now
- NaNs are ignored using (nan: true) option in Numo
  - including small change in `mean`, `median`, `std` and `var`
  - `count` shows non-NaN counts

1. There are 2 choises in DataFrame style.
   One is [count, mean, std ...] in 1st column (`summary_T`)

```ruby
puts penguins.summary_T  # in Ruby
#=>
[344,5]  bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g        year
  count           342.0          342.0              342.0        342.0       344.0
   mean        43.92193       17.15117         200.915205  4201.754386  2008.02907
    std        5.459584       1.974793          14.061714   801.954536    0.818356
    min            32.1           13.1              172.0       2700.0      2007.0
    25%          39.275           15.6              190.0       3550.0      2007.0
    50%            44.5           17.3              197.0       4050.0      2008.0
    75%          48.525           18.7              214.0      4781.25      2009.0
    max            59.6           21.5              231.0       6300.0      2009.0
```
This is default style of Pandas

```python
puts penguins_pandas.describe  # in python
#=>
       bill_length_mm  bill_depth_mm  flipper_length_mm  body_mass_g
count      342.000000     342.000000         342.000000   342.000000
mean        43.921930      17.151170         200.915205  4201.754386
std          5.459584       1.974793          14.061714   801.954536
min         32.100000      13.100000         172.000000  2700.000000
25%         39.225000      15.600000         190.000000  3550.000000
50%         44.450000      17.300000         197.000000  4050.000000
75%         48.500000      18.700000         213.000000  4750.000000
max         59.600000      21.500000         231.000000  6300.000000
```
2.  Another one is 'Transposed' style (`summary`)
      - (pros) Possible to set count as Int
      - (pros) Easy to align decimals
      - (pros) Easy to show DataFrame with many columns
      - (pros) May be easy to expand to group ?
      - (cons) Column names (keys) are transposed to vertical

```ruby
puts penguins.summary   # in ruby
#=>
          [344,5]  count         mean         std     min     25%     50%      75%     max
   bill_length_mm    342     43.92193    5.459584    32.1  39.275    44.5   48.525    59.6
    bill_depth_mm    342     17.15117    1.974793    13.1    15.6    17.3     18.7    21.5
flipper_length_mm    342   200.915205   14.061714   172.0   190.0   197.0    214.0   231.0
      body_mass_g    342  4201.754386  801.954536  2700.0  3550.0  4050.0  4781.25  6300.0
             year    344   2008.02907    0.818356  2007.0  2007.0  2008.0   2009.0  2009.0
```
For further example of this implementation kindly see [Rover_summary_example.md](https://gist.github.com/heronshoes/3d93af4cc7c55bd60185932c122c6b4e).


3. Add args for non-numeric Types (unique, top, freq) to Vector ?

4. Add non-numeric options to DataFrame#summary ?
   - describe is an alias of summary ?
   - Options like Pandas ?