### PR TITLE
Add missing Active Support dependency for Kernel#silence_warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gemspec
 gem "rake"
 gem "minitest", ">= 5"
 gem "activerecord", ">= 5"
+gem "activesupport", ">= 5"
 gem "sqlite3"
 gem "iruby", require: false
 gem "vega"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@ Bundler.require(:default)
 require "minitest/autorun"
 require "minitest/pride"
 require "active_record"
+require "active_support"
+require "active_support/core_ext/kernel/reporting"
 
 silence_warnings do
   require "iruby"


### PR DESCRIPTION
I'm having a great time with Rover! In an effort to submit a PR, I pulled down a fresh copy of the repo and ran the basic setup. It gave me an error:

```bash
git clone https://github.com/ankane/rover.git
cd rover
bundle install
bundle exec rake test

rover/test/test_helper.rb:7:in `<top (required)>': undefined method `silence_warnings' for main:Object (NoMethodError)
```

It looks like `test_helper`'s usage of `silence_warnings` actually depends on Active Support's core extensions, which was missing from the repo. Active Support allows you to cherry-pick specific extensions to require, so I added the relevant one in there and viola! The tests ran successfully.