### PR TITLE
Add support for CSV header_converters option

### DIFF
--- a/lib/rover.rb
+++ b/lib/rover.rb
@@ -41,6 +41,7 @@ module Rover
       raise ArgumentError, "Must specify headers" if headers == false
 
       # TODO use date converter in 0.4.0 - need to test performance
+      csv_options[:headers] = true if headers == true
       table = yield({converters: :numeric}.merge(csv_options))
 
       headers = nil if headers == true
@@ -48,7 +49,7 @@ module Rover
         raise ArgumentError, "Expected #{table.first.size} headers, given #{headers.size}"
       end
 
-      table_headers = (headers || table.shift || []).dup
+      table_headers = (headers || (table.respond_to?(:headers) ? table.headers : table.shift) || []).dup
       # keep same behavior as headers: true
       if table.first
         while table_headers.size < table.first.size

--- a/test/csv_test.rb
+++ b/test/csv_test.rb
@@ -92,6 +92,12 @@ class CsvTest < Minitest::Test
     assert_equal Rover::DataFrame.new({"a" => [1]}), df
   end
 
+  def test_headers_converters
+    df = Rover.read_csv("test/support/data.csv", headers: true, header_converters: :symbol)
+    assert_equal [:a, :b], df.vector_names
+    assert_equal 3, df.size
+  end
+
   def test_to_csv
     df = Rover::DataFrame.new({"a" => [1, 2, 3], "b" => ["one", "two", "three"]})
     assert_equal "a,b\n1,one\n2,two\n3,three\n", df.to_csv


### PR DESCRIPTION
I like using symbol headers because I think it makes my Rover code easier to read.

Normally with CSVs, I can use the following code to have the headers automatically converted into symbols:

```ruby
table = CSV.parse("a,b\n1,2", headers: true, header_converters: :symbol)
table.headers # => [:a, :b]
```

However, the `header_converters` CSV option doesn't work with Rover because CSV requires `headers: true` to be set, and the `#csv_to_df` private method doesn't pass it along.

```ruby
df = Rover.parse_csv("a,b\n1,2", headers: true, header_converters: :symbol)
df.vector_names # => ["a", "b"]
```

Feel free to close this PR if you'd prefer a different approach. This was the smallest code change I could make while still having all tests pass.