### PR TITLE
Simplify tally to use Array#tally

### DIFF
--- a/lib/rover/vector.rb
+++ b/lib/rover/vector.rb
@@ -185,12 +185,7 @@ module Rover
     end
 
     def tally
-      result = Hash.new(0)
-      @data.each do |v|
-        result[v] += 1
-      end
-      result.default = nil
-      result
+      @data.to_a.tally
     end
 
     def sort


### PR DESCRIPTION
This is a small improvement separated from #37.

As supported Ruby version got to be >=2.7, we can use Array#tally to simplify Vector#tally.

```
n, m = 1000000, 100
df = Rover::DataFrame.new({
    int:   Numo::Int32.new(n).rand(m),
    float: Numo::DFloat.new(n).rand(m).round,
    str:   Numo::Int32.new(n).rand(65,91).to_a.map(&:chr),
    bit:   (Numo::DFloat.new(n).rand(1) > 0.5),
  })
Benchmark.ips do |x|
  x.report("original")  { df.vectors.each {|k, v| v.tally} }
  x.report("new tally") { df.vectors.each {|k, v| v.new_tally} }
  x.compare!
end; nil
```
#=> results
```
Warming up --------------------------------------
            original     1.000  i/100ms
           new tally     1.000  i/100ms
Calculating -------------------------------------
            original      2.251  (± 0.0%) i/s -     12.000  in   5.335517s
           new tally      4.096  (± 0.0%) i/s -     21.000  in   5.129690s

Comparison:
           new tally:        4.1 i/s
            original:        2.3 i/s - 1.82x  (± 0.00) slower
```
