### PR TITLE
Fix filtering empty data frames

### DIFF
--- a/lib/rover/data_frame.rb
+++ b/lib/rover/data_frame.rb
@@ -65,6 +65,8 @@ module Rover
     end
 
     def [](where)
+      return DataFrame.new(@vectors) if where.is_a?(Vector) && empty? && where.size.zero?
+
       if (where.is_a?(Vector) && where.to_numo.is_a?(Numo::Bit)) || where.is_a?(Numeric) || where.is_a?(Range) || (where.is_a?(Array) && where.all?(Integer))
         new_vectors = {}
         @vectors.each do |k, v|

--- a/test/data_frame_test.rb
+++ b/test/data_frame_test.rb
@@ -313,6 +313,16 @@ class DataFrameTest < Minitest::Test
     assert_vector [1, 3], df[where]["a"]
   end
 
+  def test_filtering_empty_data_frame
+    df = Rover::DataFrame.new({"a" => []})
+    filtered = df[Rover::Vector.new([])]
+
+    assert_instance_of Rover::DataFrame, filtered
+    assert filtered.empty?
+    assert_equal ["a"], filtered.keys
+    assert_vector [], filtered["a"]
+  end
+
   def test_reader_missing_column
     df = Rover::DataFrame.new({"hello" => [1, 2, 3], "hello2" => ["one", "two", "three"]})
     error = assert_raises(KeyError) do


### PR DESCRIPTION

Filtering an empty `Rover::DataFrame` with an empty `Rover::Vector` returns `nil` instead of an empty dataframe.

```ruby
df = Rover::DataFrame.new({"name" => [], "value" => []})
filter = Rover::Vector.new([])

df[filter] # => nil
```

An empty vector has no values from which Rover can identify it as a Boolean filter.
Rover treats it as a column key instead, cannot find that column, and returns `nil`.

Rover now returns an empty dataframe with the same columns when an empty `Rover::Vector` filters an empty dataframe.

```ruby
df[filter] # => empty Rover::DataFrame with "name" and "value" columns
```

